### PR TITLE
Clean up page links

### DIFF
--- a/agr.html
+++ b/agr.html
@@ -26,30 +26,30 @@
   <div data-collapse="none" data-animation="default" data-duration="400" data-easing="ease" data-easing2="ease" role="banner" class="nav w-nav">
     <div class="logo w-container"><img src="images/Logo-Round_1.png" loading="lazy" sizes="(max-width: 767px) 30vw, (max-width: 991px) 218.39999389648438px, 282px" srcset="images/Logo-Round_1-p-500.png 500w, images/Logo-Round_1-p-800.png 800w, images/Logo-Round_1.png 1200w" alt="" class="image-5"></div>
     <div class="brand-name w-container">
-      <a href="index.html" aria-current="page" class="brand-link w-nav-brand w--current">
+      <a href="index" aria-current="page" class="brand-link w-nav-brand w--current">
         <h1 class="brand-text">shine design</h1>
       </a>
     </div>
-    
+
     <div class="blurb w-container">
       <p class="paragraph-3">bespoke handmade designs, for dreamers. <br>we specialize in locally found and reclaimed materials with a love for details and joinery</p>
     </div>
     <div class="contact w-container">
       <a href="https://www.google.com/maps/place/989+Pacific+St,+Brooklyn,+NY+11238/@40.6797916,-73.9615782,19z/data=!3m1!4b1!4m5!3m4!1s0x89c25ba25d7b2e95:0xe1884611a44d92bc!8m2!3d40.6797906!4d-73.9610297?authuser=1" target="_blank" class="link">📍 989 pacific st, brooklyn ny</a>
       <a href="mailto:9@shinedesign.nyc?subject=Inquiry" class="link">📧 drop me a line</a>
-      <a href="friends.html" class="link">📝 list of friends</a>
+      <a href="friends" class="link">📝 list of friends</a>
     </div>
     <div class="menu w-container">
       <nav role="navigation" class="navigation-menu w-nav-menu">
-        <a href="index.html" aria-current="page" class="page-link w-nav-link w--current">findings</a>
-        <a href="agr.html" class="page-link w-nav-link">antonio giovanni</a>
-        <a href="collabs.html" class="page-link w-nav-link">collabs</a>
+        <a href="index" aria-current="page" class="page-link w-nav-link w--current">findings</a>
+        <a href="agr" class="page-link w-nav-link">antonio giovanni</a>
+        <a href="collabs" class="page-link w-nav-link">collabs</a>
       </nav>
     </div>
   </div>
 
 
-<!-- bio --> 
+<!-- bio -->
   <div class="collection wf-section">
     <div class="section w-container">
       <div class="columns-2 w-row">
@@ -65,7 +65,7 @@
       </div>
     </div>
   </div>
-<!-- bio --> 
+<!-- bio -->
 
 
   <div class="collection wf-section">
@@ -73,60 +73,60 @@
       <div class="collection-list-wrapper w-dyn-list">
         <div role="list" class="collection-list w-clearfix w-dyn-items w-row">
 
-<!-- professional portfolio --> 
+<!-- professional portfolio -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/p/portfolio.html" class="collection-block w-inline-block"><img src="images/p/001/-cover.jpg" alt="speaker stand" class="collection-image">
+            <a href="pages/p/portfolio" class="collection-block w-inline-block"><img src="images/p/001/-cover.jpg" alt="speaker stand" class="collection-image">
               <div class="title">professional portfolio</div>
             </a>
           </div>
-<!-- professional portfolio --> 
+<!-- professional portfolio -->
 
-<!-- resume --> 
+<!-- resume -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/p/resume.html" class="collection-block w-inline-block"><img src="images/p/002/-cover.jpg" alt="speaker stand" class="collection-image">
+            <a href="pages/p/resume" class="collection-block w-inline-block"><img src="images/p/002/-cover.jpg" alt="speaker stand" class="collection-image">
               <div class="title">resume</div>
             </a>
           </div>
-<!-- resume --> 
+<!-- resume -->
 
-<!-- thesis portfolio --> 
+<!-- thesis portfolio -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/p/thesis.html" class="collection-block w-inline-block"><img src="images/p/003/-cover.jpg" alt="speaker stand" class="collection-image">
+            <a href="pages/p/thesis" class="collection-block w-inline-block"><img src="images/p/003/-cover.jpg" alt="speaker stand" class="collection-image">
               <div class="title">thesis portfolio</div>
             </a>
           </div>
-<!-- thesis portfolio --> 
+<!-- thesis portfolio -->
 
         <div class="empty-state-3 w-dyn-empty"></div>
         </div>
       </div>
-    </div> 
+    </div>
 
-<!-- writing --> 
+<!-- writing -->
     <section class="section-2 wf-section">
       <div class="empty-state-3 w-dyn-empty"></div>
       <div class="type w-richtext">
         <h2>personal writings</h2>
       </div>
     </section>
-<!-- writing --> 
+<!-- writing -->
 
     <div class="collection wf-section">
       <div class="section w-container">
         <div class="collection-list-wrapper w-dyn-list">
           <div role="list" class="collection-list w-clearfix w-dyn-items w-row">
 
-<!-- 001 - colors, dogs, lovers --> 
+<!-- 001 - colors, dogs, lovers -->
             <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-              <a href="pages/w/cdmx.html" class="collection-block w-inline-block"><img src="images/w/001/-cover.jpg" alt="cdmx - colors, dogs, lovers" class="collection-image">
+              <a href="pages/w/cdmx" class="collection-block w-inline-block"><img src="images/w/001/-cover.jpg" alt="cdmx - colors, dogs, lovers" class="collection-image">
                 <div class="title">cdmx - colors, dogs, lovers</div>
               </a>
             </div>
-<!-- 001 - colors, dogs, lovers --> 
+<!-- 001 - colors, dogs, lovers -->
 
 
           </div>
-        </div>  
+        </div>
       </div>
     </div>
   </div>

--- a/agr.html
+++ b/agr.html
@@ -26,7 +26,7 @@
   <div data-collapse="none" data-animation="default" data-duration="400" data-easing="ease" data-easing2="ease" role="banner" class="nav w-nav">
     <div class="logo w-container"><img src="images/Logo-Round_1.png" loading="lazy" sizes="(max-width: 767px) 30vw, (max-width: 991px) 218.39999389648438px, 282px" srcset="images/Logo-Round_1-p-500.png 500w, images/Logo-Round_1-p-800.png 800w, images/Logo-Round_1.png 1200w" alt="" class="image-5"></div>
     <div class="brand-name w-container">
-      <a href="index" aria-current="page" class="brand-link w-nav-brand w--current">
+      <a href="/" aria-current="page" class="brand-link w-nav-brand w--current">
         <h1 class="brand-text">shine design</h1>
       </a>
     </div>
@@ -41,7 +41,7 @@
     </div>
     <div class="menu w-container">
       <nav role="navigation" class="navigation-menu w-nav-menu">
-        <a href="index" aria-current="page" class="page-link w-nav-link w--current">findings</a>
+        <a href="/" aria-current="page" class="page-link w-nav-link w--current">findings</a>
         <a href="agr" class="page-link w-nav-link">antonio giovanni</a>
         <a href="collabs" class="page-link w-nav-link">collabs</a>
       </nav>

--- a/collabs.html
+++ b/collabs.html
@@ -25,7 +25,7 @@
   <div data-collapse="none" data-animation="default" data-duration="400" data-easing="ease" data-easing2="ease" role="banner" class="nav w-nav">
     <div class="logo w-container"><img src="images/Logo-Round_1.png" loading="lazy" sizes="(max-width: 767px) 30vw, (max-width: 991px) 218.39999389648438px, 282px" srcset="images/Logo-Round_1-p-500.png 500w, images/Logo-Round_1-p-800.png 800w, images/Logo-Round_1.png 1200w" alt="" class="image-5"></div>
     <div class="brand-name w-container">
-      <a href="index" aria-current="page" class="brand-link w-nav-brand w--current">
+      <a href="/" aria-current="page" class="brand-link w-nav-brand w--current">
         <h1 class="brand-text">shine design</h1>
       </a>
     </div>
@@ -40,7 +40,7 @@
     </div>
     <div class="menu w-container">
       <nav role="navigation" class="navigation-menu w-nav-menu">
-        <a href="index" aria-current="page" class="page-link w-nav-link w--current">findings</a>
+        <a href="/" aria-current="page" class="page-link w-nav-link w--current">findings</a>
         <a href="agr" class="page-link w-nav-link">antonio giovanni</a>
         <a href="collabs" class="page-link w-nav-link">collabs</a>
       </nav>

--- a/collabs.html
+++ b/collabs.html
@@ -25,24 +25,24 @@
   <div data-collapse="none" data-animation="default" data-duration="400" data-easing="ease" data-easing2="ease" role="banner" class="nav w-nav">
     <div class="logo w-container"><img src="images/Logo-Round_1.png" loading="lazy" sizes="(max-width: 767px) 30vw, (max-width: 991px) 218.39999389648438px, 282px" srcset="images/Logo-Round_1-p-500.png 500w, images/Logo-Round_1-p-800.png 800w, images/Logo-Round_1.png 1200w" alt="" class="image-5"></div>
     <div class="brand-name w-container">
-      <a href="index.html" aria-current="page" class="brand-link w-nav-brand w--current">
+      <a href="index" aria-current="page" class="brand-link w-nav-brand w--current">
         <h1 class="brand-text">shine design</h1>
       </a>
     </div>
-    
+
     <div class="blurb w-container">
       <p class="paragraph-3">bespoke handmade designs, for dreamers. <br>we specialize in locally found and reclaimed materials with a love for details and joinery</p>
     </div>
     <div class="contact w-container">
       <a href="https://www.google.com/maps/place/989+Pacific+St,+Brooklyn,+NY+11238/@40.6797916,-73.9615782,19z/data=!3m1!4b1!4m5!3m4!1s0x89c25ba25d7b2e95:0xe1884611a44d92bc!8m2!3d40.6797906!4d-73.9610297?authuser=1" target="_blank" class="link">📍 989 pacific st, brooklyn ny</a>
       <a href="mailto:9@shinedesign.nyc?subject=Inquiry" class="link">📧 drop me a line</a>
-      <a href="friends.html" class="link">📝 list of friends</a>
+      <a href="friends" class="link">📝 list of friends</a>
     </div>
     <div class="menu w-container">
       <nav role="navigation" class="navigation-menu w-nav-menu">
-        <a href="index.html" aria-current="page" class="page-link w-nav-link w--current">findings</a>
-        <a href="agr.html" class="page-link w-nav-link">antonio giovanni</a>
-        <a href="collabs.html" class="page-link w-nav-link">collabs</a>
+        <a href="index" aria-current="page" class="page-link w-nav-link w--current">findings</a>
+        <a href="agr" class="page-link w-nav-link">antonio giovanni</a>
+        <a href="collabs" class="page-link w-nav-link">collabs</a>
       </nav>
     </div>
   </div>
@@ -51,39 +51,39 @@
       <div class="collection-list-wrapper w-dyn-list">
         <div role="list" class="collection-list w-clearfix w-dyn-items w-row">
 
-<!-- 004 - bumalik --> 
+<!-- 004 - bumalik -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/c/bumalik.html" class="collection-block w-inline-block"><img src="images/c/004/-cover.jpg" alt="[almasphere] bumalik" class="collection-image">
+            <a href="pages/c/bumalik" class="collection-block w-inline-block"><img src="images/c/004/-cover.jpg" alt="[almasphere] bumalik" class="collection-image">
               <div class="title">[almasphere] bumalik</div>
             </a>
           </div>
-<!-- 004 - bumalik --> 
+<!-- 004 - bumalik -->
 
-<!-- 003 - spirit lounge --> 
+<!-- 003 - spirit lounge -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/c/spiritlounge.html" class="collection-block w-inline-block"><img src="images/c/003/-cover.png" alt="spirit lounge" class="collection-image">
+            <a href="pages/c/spiritlounge" class="collection-block w-inline-block"><img src="images/c/003/-cover.png" alt="spirit lounge" class="collection-image">
               <div class="title">spirit lounge</div>
             </a>
           </div>
 <!-- 003 - spirit lounge -->
 
-<!-- 002 - creatives lounge --> 
+<!-- 002 - creatives lounge -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/c/creativeslounge.html" class="collection-block w-inline-block"><img src="images/c/002/-cover.png" alt="creative's lounge" class="collection-image">
+            <a href="pages/c/creativeslounge" class="collection-block w-inline-block"><img src="images/c/002/-cover.png" alt="creative's lounge" class="collection-image">
               <div class="title">creative's lounge</div>
             </a>
           </div>
-<!-- 002 - creatives lounge --> 
+<!-- 002 - creatives lounge -->
 
-<!-- 001 - art home --> 
+<!-- 001 - art home -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/c/arthome.html" class="collection-block w-inline-block"><img src="images/c/001/-cover.jpg" alt="[almasphere] art home" class="collection-image">
+            <a href="pages/c/arthome" class="collection-block w-inline-block"><img src="images/c/001/-cover.jpg" alt="[almasphere] art home" class="collection-image">
               <div class="title">[almasphere] art home</div>
             </a>
           </div>
-<!-- 001 - art home --> 
+<!-- 001 - art home -->
 
-        </div>  
+        </div>
       </div>
     </div>
   </div>

--- a/friends.html
+++ b/friends.html
@@ -70,7 +70,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/friends.html
+++ b/friends.html
@@ -32,7 +32,7 @@
     </div>
     <div class="menu w-container">
       <nav role="navigation" class="navigation-menu w-nav-menu">
-        <a href="index" aria-current="page" class="page-link w-nav-link">findings</a>
+        <a href="/" aria-current="page" class="page-link w-nav-link">findings</a>
         <a href="agr" class="page-link w-nav-link">antonio giovanni</a>
         <a href="collabs" class="page-link w-nav-link">collabs</a>
       </nav>

--- a/friends.html
+++ b/friends.html
@@ -21,20 +21,20 @@
     <div class="brand-name w-container">
       <h1 class="brand-text">shine design</h1>
     </div>
-    
+
 <div class="blurb w-container">
       <p class="paragraph-3">bespoke handmade designs, for dreamers. <br>we specialize in locally found and reclaimed materials with a love for details and joinery</p>
     </div>
     <div class="contact w-container">
       <a href="https://www.google.com/maps/place/989+Pacific+St,+Brooklyn,+NY+11238/@40.6797916,-73.9615782,19z/data=!3m1!4b1!4m5!3m4!1s0x89c25ba25d7b2e95:0xe1884611a44d92bc!8m2!3d40.6797906!4d-73.9610297?authuser=1" target="_blank" class="link">📍 989 pacific st, brooklyn ny</a>
       <a href="mailto:9@shinedesign.nyc?subject=Inquiry" class="link">📧 drop me a line</a>
-      <a href="friends.html" class="link">📝 list of friends</a>
+      <a href="friends" class="link">📝 list of friends</a>
     </div>
     <div class="menu w-container">
       <nav role="navigation" class="navigation-menu w-nav-menu">
-        <a href="index.html" aria-current="page" class="page-link w-nav-link">findings</a>
-        <a href="agr.html" class="page-link w-nav-link">antonio giovanni</a>
-        <a href="collabs.html" class="page-link w-nav-link">collabs</a>
+        <a href="index" aria-current="page" class="page-link w-nav-link">findings</a>
+        <a href="agr" class="page-link w-nav-link">antonio giovanni</a>
+        <a href="collabs" class="page-link w-nav-link">collabs</a>
       </nav>
     </div>
   </div>
@@ -44,7 +44,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="blog-title">           </h1>
 
           <div class="collection-category"></div>
@@ -53,12 +53,12 @@
           <div class="collection-category"></div>
           <div class="collection-input"></div>
         </div>
-<!-- info --> 
+<!-- info -->
 
         <div class="column-2 w-col w-col-9">
 
           <iframe width="1080" height="1500" src="https://a4352e2b.sibforms.com/serve/MUIFAOobg4GgkCNot8Ka19y2_YUsPjAjV5-hkzGpKrWO9tQx7L2EX-kRFJ0QF6xrotjLInxDjQ-fZxffFgg6am4j_E32IkGqNoEg-4IKHhuDFtkssGVpbEQW19bS36euaWssZC8wkgdci9UWdlEFXOcx0RMlTIQgzMkq0DftXVCc8SFGAoC74XJGJaePD1wfiKruMPZQaU12B0JA" frameborder="0" scrolling="auto" allowfullscreen style="display: block;margin-left: auto;margin-right: auto;max-width: 100%;"></iframe>
-        
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -70,13 +70,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   <div data-collapse="none" data-animation="default" data-duration="400" data-easing="ease" data-easing2="ease" role="banner" class="nav w-nav">
     <div class="logo w-container"><img src="images/Logo-Round_1.png" loading="lazy" sizes="(max-width: 767px) 30vw, (max-width: 991px) 218.39999389648438px, 282px" srcset="images/Logo-Round_1-p-500.png 500w, images/Logo-Round_1-p-800.png 800w, images/Logo-Round_1.png 1200w" alt="" class="image-5"></div>
     <div class="brand-name w-container">
-      <a href="index.html" aria-current="page" class="brand-link w-nav-brand w--current">
+      <a href="index" aria-current="page" class="brand-link w-nav-brand w--current">
         <h1 class="brand-text">shine design</h1>
       </a>
     </div>
@@ -35,13 +35,13 @@
     <div class="contact w-container">
       <a href="https://www.google.com/maps/place/989+Pacific+St,+Brooklyn,+NY+11238/@40.6797916,-73.9615782,19z/data=!3m1!4b1!4m5!3m4!1s0x89c25ba25d7b2e95:0xe1884611a44d92bc!8m2!3d40.6797906!4d-73.9610297?authuser=1" target="_blank" class="link">📍 989 pacific st, brooklyn ny</a>
       <a href="mailto:9@shinedesign.nyc?subject=Inquiry" class="link">📧 drop me a line</a>
-      <a href="friends.html" class="link">📝 list of friends</a>
+      <a href="friends" class="link">📝 list of friends</a>
     </div>
     <div class="menu w-container">
       <nav role="navigation" class="navigation-menu w-nav-menu">
-        <a href="index.html" aria-current="page" class="page-link w-nav-link w--current">findings</a>
-        <a href="agr.html" class="page-link w-nav-link">antonio giovanni</a>
-        <a href="collabs.html" class="page-link w-nav-link">collabs</a>
+        <a href="index" aria-current="page" class="page-link w-nav-link w--current">findings</a>
+        <a href="agr" class="page-link w-nav-link">antonio giovanni</a>
+        <a href="collabs" class="page-link w-nav-link">collabs</a>
       </nav>
     </div>
   </div>
@@ -50,95 +50,95 @@
       <div class="collection-list-wrapper w-dyn-list">
         <div role="list" class="collection-list w-clearfix w-dyn-items w-row">
 
-<!-- 011 - sketch stacks --> 
+<!-- 011 - sketch stacks -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/sketchstacks.html" class="collection-block w-inline-block"><img src="images/f/011/-Cover.png" alt="speaker stand" class="collection-image">
+            <a href="pages/f/sketchstacks" class="collection-block w-inline-block"><img src="images/f/011/-Cover.png" alt="speaker stand" class="collection-image">
               <div class="title">sketch stacks</div>
             </a>
           </div>
-<!-- 011 - sketch stacks --> 
+<!-- 011 - sketch stacks -->
 
-<!-- 010 - 5p3i --> 
+<!-- 010 - 5p3i -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/5p3i.html" class="collection-block w-inline-block"><img src="images/f/010/cover.png" alt="speaker stand" class="collection-image">
+            <a href="pages/f/5p3i" class="collection-block w-inline-block"><img src="images/f/010/cover.png" alt="speaker stand" class="collection-image">
               <div class="title">5 poems 3 islands</div>
             </a>
           </div>
-<!-- 010 - 5p3i --> 
+<!-- 010 - 5p3i -->
 
-<!-- 009 - old growth table --> 
+<!-- 009 - old growth table -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/oldgrowthtable.html" class="collection-block w-inline-block"><img src="images/f/009/-cover.jpg" alt="speaker stand" class="collection-image">
+            <a href="pages/f/oldgrowthtable" class="collection-block w-inline-block"><img src="images/f/009/-cover.jpg" alt="speaker stand" class="collection-image">
               <div class="title">old growth table</div>
             </a>
           </div>
-<!-- 009 - old growth table --> 
+<!-- 009 - old growth table -->
 
-<!-- 008 - grandmas table --> 
+<!-- 008 - grandmas table -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/grandmastable.html" class="collection-block w-inline-block"><img src="images/f/008/-cover.jpg" alt="speaker stand" class="collection-image">
+            <a href="pages/f/grandmastable" class="collection-block w-inline-block"><img src="images/f/008/-cover.jpg" alt="speaker stand" class="collection-image">
               <div class="title">grandmas table</div>
             </a>
           </div>
-<!-- 008 - grandmas table --> 
+<!-- 008 - grandmas table -->
 
-<!-- 007 - brooklyn veranda --> 
+<!-- 007 - brooklyn veranda -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/brooklynveranda.html" class="collection-block w-inline-block"><img src="images/f/007/-cover.png" alt="speaker stand" class="collection-image">
+            <a href="pages/f/brooklynveranda" class="collection-block w-inline-block"><img src="images/f/007/-cover.png" alt="speaker stand" class="collection-image">
               <div class="title">brooklyn veranda</div>
             </a>
           </div>
-<!-- 007 - brooklyn veranda --> 
+<!-- 007 - brooklyn veranda -->
 
-<!-- 006 - sapient shelf --> 
+<!-- 006 - sapient shelf -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/sapientshelf.html" class="collection-block w-inline-block"><img src="images/f/006/-cover.jpg" alt="speaker stand" class="collection-image">
+            <a href="pages/f/sapientshelf" class="collection-block w-inline-block"><img src="images/f/006/-cover.jpg" alt="speaker stand" class="collection-image">
               <div class="title">sapient shelf</div>
             </a>
           </div>
-<!-- 006 - sapient shelf --> 
+<!-- 006 - sapient shelf -->
 
-<!-- 005 - fundaments --> 
+<!-- 005 - fundaments -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/fundaments.html" class="collection-block w-inline-block"><img src="images/f/005/-cover.jpg" alt="speaker stand" class="collection-image">
+            <a href="pages/f/fundaments" class="collection-block w-inline-block"><img src="images/f/005/-cover.jpg" alt="speaker stand" class="collection-image">
               <div class="title">fundaments</div>
             </a>
           </div>
-<!-- 005 - fundaments --> 
+<!-- 005 - fundaments -->
 
-<!-- 004 - split bench --> 
+<!-- 004 - split bench -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/splitbench.html" class="collection-block w-inline-block"><img src="images/f/004/-cover.jpg" alt="speaker stand" class="collection-image">
+            <a href="pages/f/splitbench" class="collection-block w-inline-block"><img src="images/f/004/-cover.jpg" alt="speaker stand" class="collection-image">
               <div class="title">split bench</div>
             </a>
           </div>
-<!-- 004 - split bench --> 
+<!-- 004 - split bench -->
 
-<!-- 003 - byshop table --> 
+<!-- 003 - byshop table -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/byshoptable.html" class="collection-block w-inline-block"><img src="images/f/003/-Cover.jpg" alt="speaker stand" class="collection-image">
+            <a href="pages/f/byshoptable" class="collection-block w-inline-block"><img src="images/f/003/-Cover.jpg" alt="speaker stand" class="collection-image">
               <div class="title">byshop table</div>
             </a>
           </div>
-<!-- 003 - byshop table --> 
+<!-- 003 - byshop table -->
 
-<!-- 002 - speaker stand --> 
+<!-- 002 - speaker stand -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/speakerstand.html" class="collection-block w-inline-block"><img src="images/f/002/-cover.jpg" alt="speaker stand" class="collection-image">
+            <a href="pages/f/speakerstand" class="collection-block w-inline-block"><img src="images/f/002/-cover.jpg" alt="speaker stand" class="collection-image">
               <div class="title">speaker stand</div>
             </a>
           </div>
-<!-- 002 - speaker stand --> 
+<!-- 002 - speaker stand -->
 
-<!-- 001 - [honey] --> 
+<!-- 001 - [honey] -->
           <div role="listitem" class="collection-card w-dyn-item w-col w-col-4">
-            <a href="pages/f/honey.html" class="collection-block w-inline-block"><img src="images/f/001/cover.jpg" alt="byshop table" class="collection-image">
+            <a href="pages/f/honey" class="collection-block w-inline-block"><img src="images/f/001/cover.jpg" alt="byshop table" class="collection-image">
               <div class="title">[honey]</div>
             </a>
           </div>
-<!-- 001 - honey --> 
+<!-- 001 - honey -->
 
-        </div>  
+        </div>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -25,7 +25,7 @@
   <div data-collapse="none" data-animation="default" data-duration="400" data-easing="ease" data-easing2="ease" role="banner" class="nav w-nav">
     <div class="logo w-container"><img src="images/Logo-Round_1.png" loading="lazy" sizes="(max-width: 767px) 30vw, (max-width: 991px) 218.39999389648438px, 282px" srcset="images/Logo-Round_1-p-500.png 500w, images/Logo-Round_1-p-800.png 800w, images/Logo-Round_1.png 1200w" alt="" class="image-5"></div>
     <div class="brand-name w-container">
-      <a href="index" aria-current="page" class="brand-link w-nav-brand w--current">
+      <a href="/" aria-current="page" class="brand-link w-nav-brand w--current">
         <h1 class="brand-text">shine design</h1>
       </a>
     </div>
@@ -39,7 +39,7 @@
     </div>
     <div class="menu w-container">
       <nav role="navigation" class="navigation-menu w-nav-menu">
-        <a href="index" aria-current="page" class="page-link w-nav-link w--current">findings</a>
+        <a href="/" aria-current="page" class="page-link w-nav-link w--current">findings</a>
         <a href="agr" class="page-link w-nav-link">antonio giovanni</a>
         <a href="collabs" class="page-link w-nav-link">collabs</a>
       </nav>

--- a/js/webflow.js
+++ b/js/webflow.js
@@ -1445,7 +1445,7 @@
         var location = window.location;
         var tempLink = document.createElement("a");
         var linkCurrent = "w--current";
-        var indexPage = /index\.(html|php)$/;
+        var indexPage = /\.(html|php)$/;
         var dirList = /\/$/;
         var anchors;
         var slug;

--- a/pages/c/arthome.html
+++ b/pages/c/arthome.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -154,7 +154,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/c/arthome.html
+++ b/pages/c/arthome.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">[almasphere] art home</h1>
 
           <div class="collection-category">in collaboration with</div>
@@ -46,7 +46,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">The Art Home, an art installation, is a transportable art space that allows artists and the community to share and view art in a way that is accessible.</div>
 
           <div class="collection-description">presented for free public engagement in Lower East Side, Manhattan / Little Manilla, Queens / Prospect Park, Brooklyn NY</div>
@@ -56,93 +56,93 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/01.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/02.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/03.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/04.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/05.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/06.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="i../../mages/c/001/07.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/08.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/09.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/10.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/11.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/001/12.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -154,13 +154,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/c/bumalik.html
+++ b/pages/c/bumalik.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -168,7 +168,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/c/bumalik.html
+++ b/pages/c/bumalik.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">[almasphere] bumalik</h1>
 
           <div class="collection-category">in collaboration with</div>
@@ -46,7 +46,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">an interactive spatial sculpture sets a backdrop for movement and sound</div>
 
           <div class="collection-description"></div>
@@ -56,107 +56,107 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/01.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/02.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/03.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/04.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/05.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/06.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/07.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/08.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/09.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/10.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/11.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/12.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/13.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/004/14.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -168,13 +168,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/c/creativeslounge.html
+++ b/pages/c/creativeslounge.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">creative's lounge</h1>
 
           <div class="collection-category">in collaboration with</div>
@@ -46,7 +46,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">an art show for local brooklyn creatives to share their work and engage with the community.</div>
 
           <div class="collection-description"></div>
@@ -56,71 +56,71 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/002/01.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/002/02.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/002/03.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/002/04.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/002/05.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/002/06.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/002/07.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/002/08.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
-<!-- image --> 
+<!-- image -->
+
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/c/002/09.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image -->         
+<!-- image -->
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -132,13 +132,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/c/creativeslounge.html
+++ b/pages/c/creativeslounge.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -132,7 +132,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/c/spiritlounge.html
+++ b/pages/c/spiritlounge.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">spirit lounge</h1>
 
           <div class="collection-category">in collaboration with</div>
@@ -46,10 +46,10 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">A spirituality podcast derived from our live recordings on ClubHouse. Swami (formerly known as Rishi) Chidananda is a spiritual educator and monk</div>
 
-          <div class="collection-description">We have open format discussions revolving around philosophy, self help, mindfulness and the spiritual journey. What does it mean to be spiritual? How can we improve our inner understanding of our lives and soul? What is inner joy versus external happiness? These are the kinds of questions we look to discuss, dissect and digest. 
+          <div class="collection-description">We have open format discussions revolving around philosophy, self help, mindfulness and the spiritual journey. What does it mean to be spiritual? How can we improve our inner understanding of our lives and soul? What is inner joy versus external happiness? These are the kinds of questions we look to discuss, dissect and digest.
           </div>
 
           <div class="collection-description">What does it mean to be spiritual? How can we improve our inner understanding of our lives and soul? What is inner joy versus external happiness? These are the kinds of questions we look to discuss, dissect and digest. </div>
@@ -58,115 +58,115 @@
 
         <div class="column-right w-col w-col-9">
 
-<!-- 010 - Escaping Reality --> 
+<!-- 010 - Escaping Reality -->
           <div class="rich-text-block-5 w-richtext">
-            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Escaping-Reality--on-the-Spiritual-Path-e1lqq2v/a-a8ahcfg" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>        
-            <div class="rich-text-block-5 w-richtext">Escaping Reality 🏃🏽‍♂️🌎 on the Spiritual Path</div> 
+            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Escaping-Reality--on-the-Spiritual-Path-e1lqq2v/a-a8ahcfg" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
+            <div class="rich-text-block-5 w-richtext">Escaping Reality 🏃🏽‍♂️🌎 on the Spiritual Path</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 010 - Escaping Reality --> 
+<!-- 010 - Escaping Reality -->
 
-<!-- 009 - good vibes only --> 
+<!-- 009 - good vibes only -->
           <div class="rich-text-block-5 w-richtext">
-            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Is-the-spiritual-path-good-vibes-only-e1cuau9/a-a7do9a0" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>        
-            <div class="rich-text-block-5 w-richtext">Is the spiritual path good vibes only 🤔</div> 
+            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Is-the-spiritual-path-good-vibes-only-e1cuau9/a-a7do9a0" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
+            <div class="rich-text-block-5 w-richtext">Is the spiritual path good vibes only 🤔</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 009 - good vibes only --> 
+<!-- 009 - good vibes only -->
 
-<!-- 008 - Feeling alone --> 
+<!-- 008 - Feeling alone -->
           <div class="rich-text-block-5 w-richtext">
-            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Feeling-alone--on-the-spiritual-path-e1cubao/a-a7dodu4" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>         
-            <div class="rich-text-block-5 w-richtext">Feeling alone 👣🏝 on the spiritual path</div> 
+            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Feeling-alone--on-the-spiritual-path-e1cubao/a-a7dodu4" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
+            <div class="rich-text-block-5 w-richtext">Feeling alone 👣🏝 on the spiritual path</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 008 - Feeling alone --> 
+<!-- 008 - Feeling alone -->
 
-<!-- 007 - Dealing with self doubt --> 
+<!-- 007 - Dealing with self doubt -->
           <div class="rich-text-block-5 w-richtext">
             <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Dealing-with-self-doubt-on-the-spiritual-path-e1cuco3/a-a781ms2" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
-            <div class="rich-text-block-5 w-richtext">Dealing with self doubt🪞🤔 on the spiritual path</div> 
+            <div class="rich-text-block-5 w-richtext">Dealing with self doubt🪞🤔 on the spiritual path</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 007 - Dealing with self doubt --> 
+<!-- 007 - Dealing with self doubt -->
 
-<!-- 006 - What is grace --> 
+<!-- 006 - What is grace -->
           <div class="rich-text-block-5 w-richtext">
-            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/What-is-grace--on-the-spiritual-path-e1fgb0c/a-a7i31el" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>      
-            <div class="rich-text-block-5 w-richtext">What is grace ✨ on the spiritual path</div> 
+            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/What-is-grace--on-the-spiritual-path-e1fgb0c/a-a7i31el" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
+            <div class="rich-text-block-5 w-richtext">What is grace ✨ on the spiritual path</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 006 - What is grace --> 
+<!-- 006 - What is grace -->
 
-<!-- 005 - how do we act --> 
+<!-- 005 - how do we act -->
           <div class="rich-text-block-5 w-richtext">
-            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/How-do-we-act-when-no-one-is-looking-e1fgb4l/a-a7i320f" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>      
-            <div class="rich-text-block-5 w-richtext">How do we act 🚶🏽‍♀️when no one is looking 👀</div> 
+            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/How-do-we-act-when-no-one-is-looking-e1fgb4l/a-a7i320f" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
+            <div class="rich-text-block-5 w-richtext">How do we act 🚶🏽‍♀️when no one is looking 👀</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 005 - how do we act --> 
+<!-- 005 - how do we act -->
 
-<!-- 004 - finding purpose --> 
+<!-- 004 - finding purpose -->
           <div class="rich-text-block-5 w-richtext">
-          <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Finding--purpose-in-Life-e1fgb87/a-a7i32jd" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>        
-            <div class="rich-text-block-5 w-richtext">Finding 🕵🏼‍♀️ purpose in Life 🌎</div> 
+          <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Finding--purpose-in-Life-e1fgb87/a-a7i32jd" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
+            <div class="rich-text-block-5 w-richtext">Finding 🕵🏼‍♀️ purpose in Life 🌎</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 004 - finding purpose --> 
+<!-- 004 - finding purpose -->
 
-<!-- 003 - spiritual mirror --> 
+<!-- 003 - spiritual mirror -->
           <div class="rich-text-block-5 w-richtext">
-            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/How-our-spiritual-mirror--affects-world-view-e1fgb9b/a-a7i32ng" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>      
-            <div class="rich-text-block-5 w-richtext">How our spiritual mirror 🪞 affects world view 👀</div> 
+            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/How-our-spiritual-mirror--affects-world-view-e1fgb9b/a-a7i32ng" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
+            <div class="rich-text-block-5 w-richtext">How our spiritual mirror 🪞 affects world view 👀</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 003 - spiritual mirror --> 
+<!-- 003 - spiritual mirror -->
 
-<!-- 002 - seeking vs finding --> 
+<!-- 002 - seeking vs finding -->
           <div class="rich-text-block-5 w-richtext">
-            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Seeking--vs-Finding--on-the-spiritual-path-e1cubtq/a-a781ifj" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>         
-            <div class="rich-text-block-5 w-richtext">Seeking 🔎 vs Finding 😮 on the spiritual path</div> 
+            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Seeking--vs-Finding--on-the-spiritual-path-e1cubtq/a-a781ifj" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
+            <div class="rich-text-block-5 w-richtext">Seeking 🔎 vs Finding 😮 on the spiritual path</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 002 - seeking vs finding --> 
+<!-- 002 - seeking vs finding -->
 
-<!-- 001 - Being thankful --> 
+<!-- 001 - Being thankful -->
           <div class="rich-text-block-5 w-richtext">
-            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Being-thankful--when-things-dont-work-out-e1fgatj/a-a7i312s" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>         
-            <div class="rich-text-block-5 w-richtext">Being thankful 🙏🏽 when things don’t work out 🤦🏽</div> 
+            <iframe src="https://podcasters.spotify.com/pod/show/spiritlounge/embed/episodes/Being-thankful--when-things-dont-work-out-e1fgatj/a-a7i312s" height="102px" width="400px" frameborder="0" scrolling="no"></iframe>
+            <div class="rich-text-block-5 w-richtext">Being thankful 🙏🏽 when things don’t work out 🤦🏽</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 001 - Being thankful --> 
+<!-- 001 - Being thankful -->
 
         </div>
 
@@ -177,9 +177,9 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>

--- a/pages/c/spiritlounge.html
+++ b/pages/c/spiritlounge.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -177,7 +177,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/5p3i.html
+++ b/pages/f/5p3i.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -66,60 +66,60 @@
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
 
-<!-- 001 - ground air light --> 
+<!-- 001 - ground air light -->
           <div class="rich-text-block-5 w-richtext">
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="../../images/f/010/01.mp4" frameborder="0" allowfullscreen></iframe>
-            </div>  
-            <div class="rich-text-block-5 w-richtext">01 - ground air light // puerto rico</div> 
+            </div>
+            <div class="rich-text-block-5 w-richtext">01 - ground air light // puerto rico</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 001 - ground air light --> 
+<!-- 001 - ground air light -->
 
-<!-- 002 - one tree --> 
+<!-- 002 - one tree -->
           <div class="rich-text-block-5 w-richtext">
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="../../images/f/010/02.mp4" frameborder="0" allowfullscreen></iframe>
-            </div>  
-            <div class="rich-text-block-5 w-richtext">02 - one tree bearing one fruit // iceland</div> 
+            </div>
+            <div class="rich-text-block-5 w-richtext">02 - one tree bearing one fruit // iceland</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 002 - one tree --> 
+<!-- 002 - one tree -->
 
-<!-- 003 - those who shall --> 
+<!-- 003 - those who shall -->
           <div class="rich-text-block-5 w-richtext">
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="../../images/f/010/03.mp4" frameborder="0" allowfullscreen></iframe>
             </div>
-            <div class="rich-text-block-5 w-richtext">03 - those who shall // hawaii</div> 
+            <div class="rich-text-block-5 w-richtext">03 - those who shall // hawaii</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 003 - those who shall --> 
+<!-- 003 - those who shall -->
 
-<!-- 004 - without exception --> 
+<!-- 004 - without exception -->
           <div class="rich-text-block-5 w-richtext">
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="../../images/f/010/04.mp4" frameborder="0" allowfullscreen></iframe>
             </div>
-          <div class="rich-text-block-5 w-richtext">04 - without exception // iceland</div> 
+          <div class="rich-text-block-5 w-richtext">04 - without exception // iceland</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 004 - without exception --> 
+<!-- 004 - without exception -->
 
-<!-- 005 - leading following --> 
+<!-- 005 - leading following -->
           <div class="rich-text-block-5 w-richtext">
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="../../images/f/010/05.mp4" frameborder="0" allowfullscreen></iframe>
             </div>
-          <div class="rich-text-block-5 w-richtext">05 - leading following // puerto rico</div> 
+          <div class="rich-text-block-5 w-richtext">05 - leading following // puerto rico</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 005 - leading following --> 
+<!-- 005 - leading following -->
           </div>
         </div>
 
@@ -130,9 +130,9 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>

--- a/pages/f/5p3i.html
+++ b/pages/f/5p3i.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -130,7 +130,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/brooklynveranda.html
+++ b/pages/f/brooklynveranda.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">brooklyn veranda</h1>
 
           <div class="collection-category">completed</div>
@@ -58,7 +58,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">In the center of a Brooklyn courtyard stands a structure unique and functional. The veranda was designed to host guests outdoors, and for a sense of protection while enjoying leisure time.</div>
 
           <div class="collection-description"></div>
@@ -68,79 +68,79 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/007/1.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/007/2.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/007/3.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/007/4.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/007/5.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/007/6.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/007/7.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/007/8.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/007/9.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/007/10.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -152,13 +152,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/f/brooklynveranda.html
+++ b/pages/f/brooklynveranda.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -152,7 +152,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/byshoptable.html
+++ b/pages/f/byshoptable.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">byshop table</h1>
 
           <div class="collection-category">completed</div>
@@ -58,7 +58,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">or better or worse, the world of design has seemingly settled with its current stock of forms and standards. If it is not prescribed tradition or mimicry, then it is radical exhibitionism… We are here to change that.</div>
 
           <div class="collection-description"></div>
@@ -68,107 +68,107 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/1.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/2.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/3.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/4.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/5.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/6.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/7.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/8.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/9.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/10.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/11.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/12.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/13.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/003/14.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -180,13 +180,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/f/byshoptable.html
+++ b/pages/f/byshoptable.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -180,7 +180,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/fundaments.html
+++ b/pages/f/fundaments.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">fundaments</h1>
 
           <div class="collection-category">completed</div>
@@ -59,7 +59,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">A collection of 9 hand written poems over a period of time. Although written independantly, a common theme began to emerge once combined in my first published work. Each poem is accompanied by a unique glyph representing the energy of the piece.</div>
 
           <div class="collection-description"></div>
@@ -69,86 +69,86 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/01.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/02.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/03.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/04.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/05.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/06.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/07.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/08.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/09.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/10.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/005/11.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -160,13 +160,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/f/fundaments.html
+++ b/pages/f/fundaments.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -160,7 +160,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/grandmastable.html
+++ b/pages/f/grandmastable.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -182,7 +182,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/grandmastable.html
+++ b/pages/f/grandmastable.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">grandmas table</h1>
 
           <div class="collection-category">completed</div>
@@ -58,7 +58,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">After three different woodshops in two states, and many hours traveling I was able to create a piece that represented the highest capability and craft I have been able to achieve. This piece I dedicated to my Grandma who helped raise me.</div>
 
           <div class="collection-description"></div>
@@ -68,109 +68,109 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/1.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/2.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/3.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/4.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/5.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/6.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/7.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/8.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/9.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/10.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/11.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/12.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/13.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/008/14.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
 
-        
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -182,13 +182,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/f/honey.html
+++ b/pages/f/honey.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -168,7 +168,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/honey.html
+++ b/pages/f/honey.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -67,25 +67,25 @@
 
         <div class="column-right w-col w-col-9">
 
-<!-- 001 - long night --> 
+<!-- 001 - long night -->
           <div class="rich-text-block-5 w-richtext">
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="https://player.vimeo.com/video/82613458?h=02fcae84eb" frameborder="0" allowfullscreen></iframe>
             </div>
-          <div class="rich-text-block-5 w-richtext">01 - long night</div> 
+          <div class="rich-text-block-5 w-richtext">01 - long night</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- 001 - long night --> 
+<!-- 001 - long night -->
 
 <!-- 002 - spent words -->
           <div class="rich-text-block-5 w-richtext">
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="https://player.vimeo.com/video/83683231?h=78b466656c" frameborder="0" allowfullscreen></iframe>
             </div>
-          <div class="rich-text-block-5 w-richtext">02 - spent words</div> 
+          <div class="rich-text-block-5 w-richtext">02 - spent words</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
@@ -98,7 +98,7 @@
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="https://player.vimeo.com/video/87879295?h=fe6a848087" frameborder="0" allowfullscreen></iframe>
             </div>
-          <div class="rich-text-block-5 w-richtext">03 - deep breath</div> 
+          <div class="rich-text-block-5 w-richtext">03 - deep breath</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
@@ -111,7 +111,7 @@
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="https://player.vimeo.com/video/92437107?h=f46832c730" frameborder="0" allowfullscreen></iframe>
             </div>
-          <div class="rich-text-block-5 w-richtext">04 - path lost</div> 
+          <div class="rich-text-block-5 w-richtext">04 - path lost</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
@@ -124,7 +124,7 @@
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="https://player.vimeo.com/video/99843248?h=f806190a90" frameborder="0" allowfullscreen></iframe>
             </div>
-          <div class="rich-text-block-5 w-richtext">05 - chose path</div> 
+          <div class="rich-text-block-5 w-richtext">05 - chose path</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
@@ -137,7 +137,7 @@
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="https://player.vimeo.com/video/101269469?h=3b6ed69886" frameborder="0" allowfullscreen></iframe>
             </div>
-          <div class="rich-text-block-5 w-richtext">06 - quick rest</div> 
+          <div class="rich-text-block-5 w-richtext">06 - quick rest</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
@@ -150,7 +150,7 @@
             <div class="video-wrapper">
             <iframe class="responsive-iframe" src="https://player.vimeo.com/video/104817269?h=271a9b6571" frameborder="0" allowfullscreen></iframe>
             </div>
-          <div class="rich-text-block-5 w-richtext">07 - busy day</div> 
+          <div class="rich-text-block-5 w-richtext">07 - busy day</div>
           </div>
           <div class="empty-state-3 w-dyn-empty"></div>
           <div class="empty-state-3 w-dyn-empty"></div>
@@ -168,9 +168,9 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>

--- a/pages/f/oldgrowthtable.html
+++ b/pages/f/oldgrowthtable.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">old growth table</h1>
 
           <div class="collection-category">completed</div>
@@ -58,7 +58,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">When we strip away our understanding of what a table is.. how it looks or how the forces of gravity make itself apparent. Then we can imagine forms and details liberated from expectation.</div>
 
           <div class="collection-description"></div>
@@ -68,93 +68,93 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/1.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/2.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/3.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/4.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/5.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/6.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/7.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/8.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/9.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/10.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/11.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/009/12.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -166,13 +166,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/f/oldgrowthtable.html
+++ b/pages/f/oldgrowthtable.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -166,7 +166,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/sapientshelf.html
+++ b/pages/f/sapientshelf.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -166,7 +166,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/sapientshelf.html
+++ b/pages/f/sapientshelf.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">sapient shelf</h1>
 
           <div class="collection-category">completed</div>
@@ -58,7 +58,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">sapient - having great wisdom and discernment. in this piece structure and illusion were the driving principles.</div>
 
           <div class="collection-description"></div>
@@ -68,93 +68,93 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/1.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/2.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/3.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/4.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/5.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/6.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/7.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/8.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/9.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/10.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/11.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/006/12.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -166,13 +166,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/f/sketchstacks.html
+++ b/pages/f/sketchstacks.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -133,7 +133,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/sketchstacks.html
+++ b/pages/f/sketchstacks.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">sketch stacks</h1>
 
           <div class="collection-category">completed</div>
@@ -59,7 +59,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description"></div>
 
           <div class="collection-description"></div>
@@ -69,59 +69,59 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/011/-cover.png" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/011/01.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/011/02.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/011/03.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/011/04.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/011/05.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/011/06.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-        
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -133,13 +133,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/f/speakerstand.html
+++ b/pages/f/speakerstand.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">speaker stand</h1>
 
           <div class="collection-category">completed</div>
@@ -58,7 +58,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">The rise in digital music and sound has introduced a new feature to the dwellings of man: speakers. Why not provide a sound system with a dignified home of its own.</div>
 
           <div class="collection-description"></div>
@@ -68,72 +68,72 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/002/1.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/002/2.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/002/3.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/002/4.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/002/5.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/002/6.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/002/7.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/002/8.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/002/9.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -145,13 +145,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/f/speakerstand.html
+++ b/pages/f/speakerstand.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -145,7 +145,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/splitbench.html
+++ b/pages/f/splitbench.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -187,7 +187,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/f/splitbench.html
+++ b/pages/f/splitbench.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">split bench</h1>
 
           <div class="collection-category">completed</div>
@@ -58,7 +58,7 @@
 <!-- info -->
 
 
-<!-- description --> 
+<!-- description -->
           <div class="collection-description">a bench made from affordable grade lumber, with interlocking puzzle piece joinery</div>
 
           <div class="collection-description"></div>
@@ -68,114 +68,114 @@
         </div>
         <div class="column-right w-col w-col-9">
           <div class="w-dyn-list">
-<!-- description --> 
+<!-- description -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/1.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/2.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/3.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/4.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/5.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/6.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/7.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/8.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/9.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/10.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/11.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/12.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/13.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/14.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/f/004/15.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -187,13 +187,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/p/portfolio.html
+++ b/pages/p/portfolio.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -179,7 +179,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/p/portfolio.html
+++ b/pages/p/portfolio.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">professional portfolio</h1>
 
           <div class="collection-category">last updated</div>
@@ -50,124 +50,124 @@
 <!-- info -->
 
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
             <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/01.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/02.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/03.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/04.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/05.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/06.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/07.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/08.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/09.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/10.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/11.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/12.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/13.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/14.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/15.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/16.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/001/17.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -179,13 +179,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/p/resume.html
+++ b/pages/p/resume.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -67,7 +67,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/p/resume.html
+++ b/pages/p/resume.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">resume</h1>
 
           <div class="collection-category">last updated</div>
@@ -49,13 +49,13 @@
           <div class="w-dyn-list">
 <!-- info -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/002/01.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -67,13 +67,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/p/thesis.html
+++ b/pages/p/thesis.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="collection-title">thesis portfolio</h1>
 
           <div class="collection-category">last updated</div>
@@ -49,321 +49,321 @@
           <div class="w-dyn-list">
 <!-- info -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/01.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/02.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/03.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/04.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/05.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/06.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/07.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/08.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/09.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/10.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/11.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/12.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/13.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/14.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/15.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/16.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/17.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/18.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/19.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/20.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/21.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/22.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/23.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/24.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/25.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/26.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/27.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/28.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/29.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/30.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/31.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/32.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/33.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/34.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/35.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/36.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/37.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/38.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/39.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/40.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/41.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/42.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/43.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/44.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
             <div role="list" class="w-dyn-items">
               <div role="listitem" class="w-dyn-item"><img src="../../images/p/003/45.jpg" loading="lazy" alt="" class="collection-images"></div>
             </div>
             <div class="empty-state-3 w-dyn-empty"></div>
-<!-- image --> 
-        
+<!-- image -->
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -375,13 +375,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>

--- a/pages/p/thesis.html
+++ b/pages/p/thesis.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -375,7 +375,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/w/cdmx.html
+++ b/pages/w/cdmx.html
@@ -23,7 +23,7 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link">findings</a>
+        <a href="../../" class="page-link">findings</a>
         <a href="../../agr" class="page-link">antonio giovanni</a>
         <a href="../../collabs" class="page-link">collabs</a>
       </div>
@@ -272,7 +272,7 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../" class="page-link w-inline-block">findings</a>
         <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
         <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>

--- a/pages/w/cdmx.html
+++ b/pages/w/cdmx.html
@@ -23,9 +23,9 @@
     </div>
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link">findings</a>
-        <a href="../../agr.html" class="page-link">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link">collabs</a>
+        <a href="../../index" class="page-link">findings</a>
+        <a href="../../agr" class="page-link">antonio giovanni</a>
+        <a href="../../collabs" class="page-link">collabs</a>
       </div>
     </div>
   </div>
@@ -35,7 +35,7 @@
       <div class="photo-row w-row">
         <div class="column-left w-col w-col-3">
 
-<!-- info --> 
+<!-- info -->
           <h1 class="blog-title">mexico city - colors, dogs, lovers</h1>
 
           <div class="collection-category">location</div>
@@ -44,223 +44,223 @@
           <div class="collection-category">date</div>
           <div class="collection-input">spring 2023</div>
         </div>
-<!-- info --> 
+<!-- info -->
 
         <div class="column-2 w-col w-col-9">
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">It had been a while since I travelled outside the country, and thankfully had a spectacular time despite the last minute rushed passport experience which had me arrive at the airport with only one hour before boarding. I decided to take most of my holiday time this year and dedicate it to one long trip. It was very worth it.</div>
 
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
+<!-- paragraph -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">My "cousin" and design partner in <a href="https://www.instagram.com/alma.sphere/" target="_blank" rel="noopener noreferrer">almasphere</a>, <a href="https://www.instagram.com/sabrinaherbosa/" target="_blank" rel="noopener noreferrer">sabrina herbosa reyes</a>, had moved to CDMX some time ago to pursue her calling for sculpture and art. Through a lot of hard work, she managed to land her first solo show, and I figured what better time to visit the magical city than now. The first two nights I crashed at her apartment which was conveniently located near the gallery.. In a neighborhood a little similar to NYC's SoHo 'Condesa'.. or Countess.</div>
-          
+
           <div class="empty-state-3 w-dyn-empty"></div>
 <!-- paragraph -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/01.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">Immediately I fell back in love with windows and doors that did not have screens. The sun was strong there, but somehow very gentle my entire trip. It would cool off around 4/5pm as more clouds seemed to cover it up and bring in a pleasant breeze. Mornings were spent looking out the window, hearing familiar city-starting sounds of horns and shouts, mixed with street sweepers and many birds singing. I knew I couldn't keep idle for the entire trip, so decided to bring the book <a href="https://www.barnesandnoble.com/w/all-about-love-bell-hooks/1111738180" target="_blank" rel="noopener noreferrer">All About Love</a>, by Bell Hooks with me. In combination with the love energy throughout the city, it let me enjoy the serenity and magic buried inside the chaos of this metropolis.
 </div>
-          
+
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
+<!-- paragraph -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/02.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">In fact, I was fortunate enough to run into exactly 0 problems my entire stay. It seems I got them out of the way beforehand dealing with the passport agency. On the day of the opening night (my first daytime there), I spent a lot of time wondering around the two major parks in Condesa and observing the scene. Right away I noticed two very distinct things about the city.</div>
 
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
+<!-- paragraph -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">For one.. it was filled with Lovers embracing each other. I saw all ages, old married couples, young school kids, everything in between. Very tightly holding each other, kissing in a loving way that wasn't offensive for my taste at least. My entire stay, this was one of the main constants throughout. In a way it was very refreshing to see and be reminded of love's presence around me.</div>
-          
+
           <div class="empty-state-3 w-dyn-empty"></div>
 <!-- paragraph -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/04.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/03.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">The other thing that was completely abundant.. Dogs. Big dogs, little dogs, mostly without collars, sometimes being watched by a person 10-15 at a time! One of the first steps into the park I saw an entire army of dogs laying on the path with mats the watcher had set out. And I thought, are they perhaps selling them they have so many?!! The dogs where a little less refreshing than the lovers, but they were all well behaved. Even though they ran around and jumped over fences into the gardens, they never bumped into a human, or caused a commotion.</div>
-          
+
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
+<!-- paragraph -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/05.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">After the show, I headed north to a much more lowkey neighborhood called <a href="https://en.wikipedia.org/wiki/Colonia_Santa_Mar%C3%ADa_la_Ribera" target="_blank" rel="noopener noreferrer">Santa Marie La Riberia</a>.. What made this part, being my longest stay in one place, so special was <a href="https://www.airbnb.com/rooms/plus/23002001?source_impression_id=p3_1691718205_ix38mCkhgmuI1D55" target="_blank" rel="noopener noreferrer">the airbnb</a> I was able to stay in. It almost felt like a dream. The room was an old compound used for an ambassador in times long past. The courtyard was the most magical space I have lived around ever in my life. The room itself was also the largest space I had ever stayed in. It wasn't just the size, but certain elements that made it so magic.
 </div>
-          
+
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
+<!-- paragraph -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/06.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/07.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">In the morning and early eve, the trees in the courtyard were filled with birds chatting about their day with each other. It felt like an entire swarm, but their constant sound was so refreshing and soothing, as a sonic book-end to my days. I would open my windows (without screens) in the mornings and let the breeze help wake me up, enjoying the shade of the portico as I did my daily meditations. On my last two night I was fortunate enough to experience a thunderstorm, as I sit reflecting on my time, the rain never touching me physically.. yet it and the thunder having the most soothing impact on me spiritually.</div>
 
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
+<!-- paragraph -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/08.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">The highlight of my trip, was seeing one of my top three architects of all time (the only one I had not experienced yet): <a href="https://en.wikipedia.org/wiki/Luis_Barrag%C3%A1n" target="_blank" rel="noopener noreferrer">Luis Barragán</a>. I haven't thought about his building in weeks as I write this now, and even just typing the name makes my heart quiver in the joy of memory.</div>
-          
+
           <div class="empty-state-3 w-dyn-empty"></div>
 <!-- paragraph -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">This trip was also very much a pilgrimage towards his work. Ever since I first read his <a href="https://www.pritzkerprize.com/sites/default/files/inline-files/1980_Acceptance_Speech.pdf" target="_blank" rel="noopener noreferrer">Pritzker Prize acceptance speech</a>, I had an affinity with Barragán and his design principles. I scheduled a tour for both <a href="https://www.barragan-foundation.org/works/list/gilardi-house" target="_blank" rel="noopener noreferrer">Casa Gilardi</a> and his <a href="https://www.barragan-foundation.org/works/list/barragan-house" target="_blank" rel="noopener noreferrer">home and studio</a>. Gilardi was the last project he made before he passed away. The potency and accrual of decades of experience were unleashed in the most subtle way here.</div>
-          
-          <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
 
-<!-- image --> 
+          <div class="empty-state-3 w-dyn-empty"></div>
+<!-- paragraph -->
+
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/09.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">I have been to many extremely beautiful and impactful pieces of architecture. I have seen buildings older than the country I live in. Nothing made the same impact on me as Casa Gilardi. It started off with some discussion and explanation from our guide, who turned out to be the son of the original owner. In fact him and his mother still live in the house. That feeling of a personal visit and tour set the emotional stage for something I was not prepared for. I had just come to make some sketches of one of the greats, take some photos... easy.</div>
-          
-          <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
 
-<!-- image --> 
+          <div class="empty-state-3 w-dyn-empty"></div>
+<!-- paragraph -->
+
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/10.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">As he invited us with a "could someone help me open the door to the hallway", I knew this was not going to be a regular tour. Everyone was shy, so naturally I did the honors. Standing in the yellow hallway, what I did not know is how perfect of a building it was. Yellow light filled the space as if someone had a smoke machine running, it was not just the color yellow.. It had a physical atmospheric presence. I whispered to myself "perfect" and continued to hold back tears of joy for the rest of my study. Once I left, I walked around the block on my way to his studio, and had to stop near a tree and break down crying (in a joyful way). I was so overwhelmed at the emotional vivacity in the space and that moment in life, I couldn't do anything but cry and express extreme gratitude for making it to this point in my journey.</div>
-          
-          <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
 
-<!-- sketch --> 
+          <div class="empty-state-3 w-dyn-empty"></div>
+<!-- paragraph -->
+
+<!-- sketch -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/s01.png" loading="lazy" alt="" class="collection-images"></div>
-<!-- sketch --> 
+<!-- sketch -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/11.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/12.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- sketch --> 
+<!-- sketch -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/s04.png" loading="lazy" alt="" class="collection-images"></div>
-<!-- sketch --> 
+<!-- sketch -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/13.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- sketch --> 
+<!-- sketch -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/s03.png" loading="lazy" alt="" class="collection-images"></div>
-<!-- sketch --> 
+<!-- sketch -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/14.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">Here I was staying in a palace all to myself, when I grew up sharing a bed with two other relatives. I made it to see one of my favorite architects of all times, when some of my close family members didn't make it to see 25 years of age.</div>
-          
-          <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
 
-<!-- paragraph --> 
+          <div class="empty-state-3 w-dyn-empty"></div>
+<!-- paragraph -->
+
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">In my younger years as an architect and designer I had not paid much attention to the emotional value or presence in a space. However one of the main take aways from my readings of 'All About Love' was the declaration that love is not an emotion, it is an action. In the city of colors and lovers, I felt the presence of the actions of love.. And it was in Casa Gilardi that it became very physical and tangible for me, for the first time in the world of architecture.</div>
-          
-          <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
 
-<!-- image --> 
+          <div class="empty-state-3 w-dyn-empty"></div>
+<!-- paragraph -->
+
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/15.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- paragraph --> 
+<!-- paragraph -->
           <div class="rich-text-block-4 w-richtext">There were other incredible moments in my stay in Cuidad de Mexico as well. My pilgrimage was very successful and I can certainly see myself returning there again in the future.</div>
-          
+
           <div class="empty-state-3 w-dyn-empty"></div>
-<!-- paragraph --> 
+<!-- paragraph -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/16.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/17.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/18.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/19.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- sketch --> 
+<!-- sketch -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/s05.png" loading="lazy" alt="" class="collection-images"></div>
-<!-- sketch --> 
+<!-- sketch -->
 
-<!-- sketch --> 
+<!-- sketch -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/s07.png" loading="lazy" alt="" class="collection-images"></div>
-<!-- sketch --> 
+<!-- sketch -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/20.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/21.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/22.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/23.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-<!-- sketch --> 
+<!-- sketch -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/s08.png" loading="lazy" alt="" class="collection-images"></div>
-<!-- sketch --> 
+<!-- sketch -->
 
-<!-- image --> 
+<!-- image -->
           <div class="rich-text-block-4 w-richtext"><img src="../../images/w/001/24.jpg" loading="lazy" alt="" class="collection-images"></div>
-<!-- image --> 
+<!-- image -->
 
-        
+
 
           </div>
           <div class="rich-text-block-5 w-richtext"></div>
@@ -272,13 +272,13 @@
   <div class="section-2 wf-section">
     <div class="menu w-container">
       <div class="navigation-menu">
-        <a href="../../index.html" class="page-link w-inline-block">findings</a>
-        <a href="../../agr.html" class="page-link w-inline-block">antonio giovanni</a>
-        <a href="../../collabs.html" class="page-link w-inline-block">collabs</a>
+        <a href="../../index" class="page-link w-inline-block">findings</a>
+        <a href="../../agr" class="page-link w-inline-block">antonio giovanni</a>
+        <a href="../../collabs" class="page-link w-inline-block">collabs</a>
       </div>
     </div>
   </div>
-  
+
   <script src="https://d3e54v103j8qbb.cloudfront.net/js/jquery-3.5.1.min.dc5e7f18c8.js?site=633906ddf6ee9708ae4f03dc" type="text/javascript" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
   <script src="../../js/webflow.js" type="text/javascript"></script>
 </body>


### PR DESCRIPTION
This ensures links navigate to pages like `https://shinedesign.nyc/agr` instead of `https://shinedesign.nyc/agr.html` which looks a lot cleaner.  Also, `/index.html` is the same as `/` so those have also been converted for better aesthetics.